### PR TITLE
Settings

### DIFF
--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -5,12 +5,12 @@ import { getNonce } from "./getNonce";
 import { TokenManager } from "./TokenManager";
 import { ToolboxPanel } from "./ToolboxPanel";
 
-export let keywords = "";
 
 export class SidebarProvider implements vscode.WebviewViewProvider {
     _view?: vscode.WebviewView;
     _doc?: vscode.TextDocument;
     private static sidebarWebview: vscode.Webview;
+    public static keywords = ""; // TODO make private and add getter/setter
 
     constructor(private readonly _extensionUri: vscode.Uri) { }
 
@@ -21,7 +21,6 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         webviewView.webview.options = {
             // Allow scripts in the webview
             enableScripts: true,
-
             localResourceRoots: [this._extensionUri],
         };
 
@@ -34,8 +33,8 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
                     break;
                 }
                 case "startListen": {
-                    if (!keywords) {
-                      keywords = data.value; // set keywords the first time
+                    if (!SidebarProvider.keywords) {
+                      SidebarProvider.keywords = data.value; // set keywords the first time
                     }
                     vscode.commands.executeCommand("snippetbox.listen");
                     ToolboxPanel.getPanelWebview()?.postMessage({

--- a/src/ToolboxPanel.ts
+++ b/src/ToolboxPanel.ts
@@ -2,8 +2,6 @@ import * as vscode from "vscode";
 import { getNonce } from "./getNonce";
 import { SidebarProvider } from "./SidebarProvider";
 
-export let keywords = "";
-
 export class ToolboxPanel {
   /**
    * Track the current panel. Only allow a single panel to exist at a time.
@@ -11,6 +9,8 @@ export class ToolboxPanel {
   public static currentPanel: ToolboxPanel | undefined;
 
   public static readonly viewType = "toolbox";
+
+  public static keywords = ""; // TODO make private and add getter/setter
 
   private readonly _panel: vscode.WebviewPanel;
   private readonly _extensionUri: vscode.Uri;
@@ -32,6 +32,7 @@ export class ToolboxPanel {
       // ToolboxPanel.currentPanel._update(); removed to prevent panel from being reinitiated
       return;
     }
+
 
     // Otherwise, create a new panel.
     const panel = vscode.window.createWebviewPanel(
@@ -119,8 +120,8 @@ export class ToolboxPanel {
     webview.onDidReceiveMessage(async (data) => {
       switch (data.type) {
         case "startListen": {
-          if (!keywords) {
-            keywords = data.value; // set keywords the first time
+          if (!ToolboxPanel.keywords) {
+            ToolboxPanel.keywords = data.value; // set keywords the first time
           }
           vscode.commands.executeCommand("snippetbox.listen");
           SidebarProvider.getWebview()?.postMessage({

--- a/src/ToolboxPanel.ts
+++ b/src/ToolboxPanel.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { getNonce } from "./getNonce";
+import { SidebarProvider } from "./SidebarProvider";
 
 export let keywords = "";
 
@@ -122,10 +123,18 @@ export class ToolboxPanel {
             keywords = data.value; // set keywords the first time
           }
           vscode.commands.executeCommand("snippetbox.listen");
+          SidebarProvider.getWebview()?.postMessage({
+            type: "listening",
+            value: "on",
+          });
           break;
         }
         case "stopListen": {
           vscode.commands.executeCommand("snippetbox.stopListen");
+          SidebarProvider.getWebview()?.postMessage({
+            type: "listening",
+            value: "off",
+          });
           break;
         }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,13 +3,14 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import { ToolboxPanel, keywords } from './ToolboxPanel';
+import { ToolboxPanel } from './ToolboxPanel';
 import { SidebarProvider } from './SidebarProvider';
 import { authenticate } from './authenticate';
 import { TokenManager } from './TokenManager';
 import { SpeechClient } from './SpeechClient';
 
 let speechClientInitiated = false;
+let keywords = "";
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -134,7 +135,12 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand('snippetbox.listen', async () => {
 			try {
 				if (!speechClientInitiated) {
-					console.log(JSON.parse(keywords));
+					if (ToolboxPanel.keywords) {
+						keywords = ToolboxPanel.keywords;
+					} else if (SidebarProvider.keywords) {
+						keywords = SidebarProvider.keywords;
+					}
+					console.log(JSON.parse(keywords)); // error here if turn listen on from settings
 					await SpeechClient.startSpeechRecognition(JSON.parse(keywords));
 					speechClientInitiated = true;
 				}

--- a/webviews/components/Sidebar.svelte
+++ b/webviews/components/Sidebar.svelte
@@ -1,50 +1,80 @@
 <script lang="ts">
 import { onMount } from "svelte";
-import type { User, State } from "../types";
-import Todos from "./Todos.svelte";
+import { keywords } from "../references";
+// import type { User, State } from "../types";
+// import Todos from "./Todos.svelte";
 
-    let accessToken = '';
-    let loading = true;
-    let user: User | null = null;
-    let lastState = tsvscode.getState();
-    let page: "todos" | "contact" = lastState?.page || "todos";
-    let text = lastState?.text || "";
-    let state: State = {page, text};
+    // let accessToken = '';
+    // let loading = true;
+    // let user: User | null = null;
+    // let lastState = tsvscode.getState();
+    // let page: "todos" | "contact" = lastState?.page || "todos";
+    // let text = lastState?.text || "";
+    // let state: State = {page, text};
+    let listenSettingOn = false;
+    let notificationsSettingOn = true;
 
     // will be called every time any variable in here changes
-    $: {
-        tsvscode.setState({state});
-    }
+    // $: {
+    //     tsvscode.setState({state});
+    // }
 
     // gets run when panel first gets mounted, good place to add listeners
     onMount(async () => {
         window.addEventListener("message", async (event) => {
             const message = event.data; // The json data that the extension sent
             switch (message.type) {
-                case 'token':
-                    accessToken = message.value;
-                    const response = await fetch(`${apiBaseUrl}/me`, {
-                        headers: {
-                            authorization: `Bearer ${accessToken}`,
-                        },
-                    });
-                    const data = await response.json();
-                    user = data.user;
-                    loading = false;
+                // case 'token':
+                //     accessToken = message.value;
+                //     const response = await fetch(`${apiBaseUrl}/me`, {
+                //         headers: {
+                //             authorization: `Bearer ${accessToken}`,
+                //         },
+                //     });
+                //     const data = await response.json();
+                //     user = data.user;
+                //     loading = false;
+                //     break;
+                case 'setting':
+                    break;
             }
         });
 
-        tsvscode.postMessage({type: 'get-token', value: undefined});
+        // tsvscode.postMessage({type: 'get-token', value: undefined});
 
         
     });
 </script>
 
-{#if loading}
+<style>
+    h3 {
+        display: inline-block;
+        margin: 1px;
+        padding: 3px;
+    }
+
+    h2 {
+        border-bottom: 1px solid var(--vscode-input-placeholderForeground);
+        padding: 1px;
+    }
+
+    .openToolbox {
+        width: 100%;
+    }
+
+    .settingButton {
+        float: right;
+        padding: 3px 5px;
+        margin: 1px;
+    }
+
+</style>
+
+<!-- {#if loading}
     <div>loading...</div>
-{:else if user}
+{:else if user} -->
     <!-- <pre>{JSON.stringify(user, null, 2)}</pre> -->
-    {#if state.page === 'todos'}
+    <!-- {#if state.page === 'todos'}
         <Todos {user} {accessToken} bind:text/>
         <button on:click={() => {
             console.log(`clicked contact, state page: ${state.page}`);
@@ -53,12 +83,51 @@ import Todos from "./Todos.svelte";
             };
             lastState.text = text;
             console.log(`clicked contact-after, state page: ${state.page}`);
-        }}>go to contact</button>
+        }}>go to contact</button> -->
         <!-- svelte-ignore missing-declaration -->
-        <button on:click={() => {
+        <button class="openToolbox" on:click={() => {
             tsvscode.postMessage({type: 'toolbox', value: undefined});
         }}>Open Toolbox</button>
-    {:else}
+        <h2>Settings</h2>
+    <div>
+        <h3>Listening: </h3>
+        {#if listenSettingOn}
+            <!-- svelte-ignore missing-declaration -->
+            <button class="settingButton" on:click={()=> {
+            // send message to extension
+            tsvscode.postMessage({type: 'stopListen', value: undefined});
+            listenSettingOn = false; // might want to do this after getting confirmation?
+            }}>ON</button>
+            
+        {:else}
+            <!-- svelte-ignore missing-declaration -->
+            <button class="settingButton" title="Turn on for suggested references" on:click={()=> {
+            // send message to extension
+            tsvscode.postMessage({type: 'startListen', value: keywords});
+            listenSettingOn = true;
+            }}>OFF</button>
+        {/if}
+    </div>
+    <div>
+        <h3>Notifications: </h3>
+        {#if notificationsSettingOn}
+            <!-- svelte-ignore missing-declaration -->
+            <button class="settingButton" on:click={()=> {
+            // send message to extension
+            tsvscode.postMessage({type: 'stopNotifications', value: undefined});
+            notificationsSettingOn = false; // might want to do this after getting confirmation?
+            }}>ON</button>
+            
+        {:else}
+            <!-- svelte-ignore missing-declaration -->
+            <button class="settingButton" title="Turn on for reference notifcations" on:click={()=> {
+            // send message to extension
+            tsvscode.postMessage({type: 'startNotifications', value: keywords});
+            notificationsSettingOn = true;
+            }}>OFF</button>
+        {/if}
+    </div>
+    <!-- {:else}
         <a href="https://scholar.google.com/citations?user=AVSNW8gAAAAJ&hl=en&oi=ao">Google Scholar Page</a>
         <button on:click={() => {
             console.log(`clicked back, state page: ${state.page}`);
@@ -68,17 +137,17 @@ import Todos from "./Todos.svelte";
             };
             console.log(`clicked back-after, state page: ${state.page}`);
         }}>go back</button>
-    {/if}
+    {/if} -->
     <!-- svelte-ignore missing-declaration -->
-    <button on:click={() => {
+    <!-- <button on:click={() => {
         accessToken='';
         user = null;
         tsvscode.postMessage({type: 'logout', value: undefined});
     }}>logout</button>
-{:else}
+{:else} -->
     <!-- svelte-ignore missing-declaration -->
-    <button on:click={() => {
+    <!-- <button on:click={() => {
         tsvscode.postMessage({type: 'authenticate', value: undefined});
     }}>login with GitHub</button>
-{/if}
+{/if} -->
 

--- a/webviews/components/Sidebar.svelte
+++ b/webviews/components/Sidebar.svelte
@@ -35,7 +35,12 @@ import { keywords } from "../references";
                 //     user = data.user;
                 //     loading = false;
                 //     break;
-                case 'setting':
+                case 'listening':
+                    if (message.value === "on") {
+                        listenSettingOn = true;
+                    } else if (message.value === "off") {
+                        listenSettingOn = false;
+                    }
                     break;
             }
         });
@@ -122,7 +127,7 @@ import { keywords } from "../references";
             <!-- svelte-ignore missing-declaration -->
             <button class="settingButton" title="Turn on for reference notifcations" on:click={()=> {
             // send message to extension
-            tsvscode.postMessage({type: 'startNotifications', value: keywords});
+            tsvscode.postMessage({type: 'startNotifications', value: undefined});
             notificationsSettingOn = true;
             }}>OFF</button>
         {/if}

--- a/webviews/components/Sidebar.svelte
+++ b/webviews/components/Sidebar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { onMount } from "svelte";
 import { keywords } from "../references";
-// import type { User, State } from "../types";
+import type { State } from "../types";
 // import Todos from "./Todos.svelte";
 
     // let accessToken = '';
@@ -10,14 +10,20 @@ import { keywords } from "../references";
     // let lastState = tsvscode.getState();
     // let page: "todos" | "contact" = lastState?.page || "todos";
     // let text = lastState?.text || "";
-    // let state: State = {page, text};
-    let listenSettingOn = false;
-    let notificationsSettingOn = true;
+    let lastState = tsvscode.getState();
+    let listenSettingOn = lastState?.listenSettingOn || false;
+    let notificationsSettingOn = lastState?.notificationsSettingOn || true;
+    let toolboxInitiated = lastState?.toolboxInitiated || false;
+    let state: State = {listenSettingOn, notificationsSettingOn, toolboxInitiated};
 
     // will be called every time any variable in here changes
-    // $: {
-    //     tsvscode.setState({state});
-    // }
+    $: {
+        tsvscode.setState({ 
+            listenSettingOn: listenSettingOn, 
+            notificationsSettingOn: notificationsSettingOn, 
+            toolboxInitiated: toolboxInitiated,
+        });
+    }
 
     // gets run when panel first gets mounted, good place to add listeners
     onMount(async () => {
@@ -92,7 +98,9 @@ import { keywords } from "../references";
         <!-- svelte-ignore missing-declaration -->
         <button class="openToolbox" on:click={() => {
             tsvscode.postMessage({type: 'toolbox', value: undefined});
+            toolboxInitiated = true;
         }}>Open Toolbox</button>
+    {#if toolboxInitiated}
         <h2>Settings</h2>
     <div>
         <h3>Listening: </h3>
@@ -132,6 +140,7 @@ import { keywords } from "../references";
             }}>OFF</button>
         {/if}
     </div>
+    {/if}
     <!-- {:else}
         <a href="https://scholar.google.com/citations?user=AVSNW8gAAAAJ&hl=en&oi=ao">Google Scholar Page</a>
         <button on:click={() => {

--- a/webviews/components/Toolbox.svelte
+++ b/webviews/components/Toolbox.svelte
@@ -19,7 +19,7 @@
   let listening: boolean = false;
   let isSearchPage: boolean = true;
   let favorites: Array<Ref> = Ref.getAllFavorites();
-  let keywords = JSON.stringify(Ref.getAllKeywords());
+  let keywords = JSON.stringify(Ref.getAllKeywords()); // could prob replace this with Ref.keywords
   let isVisible: boolean;
 
     // will be called every time any variable in here changes
@@ -208,13 +208,17 @@
     outline: 0px;
   }
 
+  .onOff {
+    padding: 3px 5px;
+  }
+
 </style>
 
 <div>
   <h3>Listening is</h3>
   {#if listening}
     <!-- svelte-ignore missing-declaration -->
-    <button on:click={()=> {
+    <button class="onOff" on:click={()=> {
       // send message to extension
       tsvscode.postMessage({type: 'stopListen', value: undefined});
       listening = false; // might want to do this after getting confirmation?
@@ -222,7 +226,7 @@
     
   {:else}
     <!-- svelte-ignore missing-declaration -->
-    <button title="Turn on for suggested references" on:click={()=> {
+    <button class="onOff" title="Turn on for suggested references" on:click={()=> {
       // send message to extension
       tsvscode.postMessage({type: 'startListen', value: keywords});
       listening = true;

--- a/webviews/components/Toolbox.svelte
+++ b/webviews/components/Toolbox.svelte
@@ -21,6 +21,7 @@
   let favorites: Array<Ref> = Ref.getAllFavorites();
   let keywords = JSON.stringify(Ref.getAllKeywords()); // could prob replace this with Ref.keywords
   let isVisible: boolean;
+  let notifications: boolean;
 
     // will be called every time any variable in here changes
     // $: {
@@ -120,6 +121,22 @@
                   case "visible":
                    isVisible = message.value;
                   break;
+                  case "setting":
+                    switch (message.value) {
+                      case "startListen":
+                        listening = true;
+                        break;
+                      case "stopListen":
+                        listening = false;
+                        break;
+                      case "startNotifications":
+                        notifications = true;
+                        break;
+                      case "stopNotifications":
+                        notifications = false;
+                        break;
+                    }
+                    break;
             }
 
         });

--- a/webviews/components/Toolbox.svelte
+++ b/webviews/components/Toolbox.svelte
@@ -21,7 +21,7 @@
   let favorites: Array<Ref> = Ref.getAllFavorites();
   let keywords = JSON.stringify(Ref.getAllKeywords()); // could prob replace this with Ref.keywords
   let isVisible: boolean;
-  let notifications: boolean;
+  let notifications: boolean = true;
 
     // will be called every time any variable in here changes
     // $: {
@@ -95,7 +95,7 @@
                   // search through Refs with keywords
                   listenSearch(message.value);
                   // TODO: also show notifications if the toolbox is hidden
-                  if (listening && (!isSearchPage || isVisible)) { // if not on search page show as notifications
+                  if (listening && notifications && (!isSearchPage || !isVisible)) { // if not on search page show as notifications
                     // only show new resources so it is not overwhelming/annoying
                     for (let i = 0; i < listenResults.length; i++) {
                       if (listenResults[i].isNew()) {
@@ -119,7 +119,7 @@
                     }
                     break;
                   case "visible":
-                   isVisible = message.value;
+                   isVisible = (message.value === "true");
                   break;
                   case "setting":
                     switch (message.value) {

--- a/webviews/references.ts
+++ b/webviews/references.ts
@@ -169,3 +169,4 @@ let ref3 = new Ref(
     ["regular", "expression", "regex", "match"],
 );
 export let references: Array<Ref> = [ref1, ref2, ref3];
+export let keywords = JSON.stringify(Ref.getAllKeywords());

--- a/webviews/references.ts
+++ b/webviews/references.ts
@@ -86,8 +86,12 @@ export class Ref {
         }
     }
 
-    public toggleSaveStatus() {
-        this.saved = !this.saved;
+    public toggleSaveStatus(save?: boolean) {
+        if (save) { // specify saved or not
+            this.saved = true;
+        } else { // toggle
+            this.saved = !this.saved;
+        }   
     }
 
     public setNotNew() {

--- a/webviews/types.ts
+++ b/webviews/types.ts
@@ -4,6 +4,11 @@ export type User = {
     githubId: string;
 };
 
-export type State = 
-    | {page: "todos"; text: string;}
-    | {page: "contact"};
+// export type State = 
+//     | {page: "todos"; text: string;}
+//     | {page: "contact"};
+export type State = {
+    listenSettingOn: boolean;
+    notificationsSettingOn: boolean; 
+    toolboxInitiated: boolean;
+};


### PR DESCRIPTION
Removed old content from the original tutorial. Added settings (just listening and notifications for now). Keywords are sent to speech client regardless of whether listening was turned on from the settings/sidebar or from the toolbox panel. Settings in sidebar are synchronized with Toolbox Panel. Current setup requires user to "open toolbox" before accessing settings. May change this in the future by passing info about the settings to the initial panel creation.